### PR TITLE
Enable GitHub posts sync

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -57,6 +57,12 @@
                 <li>Use Markdown-style formatting: **bold**, *italic*, # headings, - lists</li>
                 <li>Mark one post as "Featured" to highlight it on the homepage</li>
             </ul>
+            <div style="margin-top: 1.5rem;">
+                <label for="github-token" style="display:block; margin-bottom:0.5rem;">GitHub Token</label>
+                <input type="password" id="github-token" placeholder="ghp_..." style="width:100%; margin-bottom:0.5rem;">
+                <button class="btn btn-primary" onclick="syncToGitHub()">Sync Posts to GitHub</button>
+                <p style="color:#6b7280; font-size:0.875rem; margin-top:0.5rem;">Token is used only in your browser to update <code>posts.json</code>.</p>
+            </div>
         </div>
     </div>
 

--- a/posts.json
+++ b/posts.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": 1,
+    "title": "The Future of Digital Journalism in 2024",
+    "excerpt": "Exploring how AI and new technologies are reshaping the landscape of modern journalism and what it means for reporters.",
+    "content": "# The Future of Digital Journalism in 2024\n\nThe landscape of journalism is evolving at an unprecedented pace. As we navigate through 2024, digital transformation continues to reshape how we gather, verify, and distribute news.\n\n## The Rise of AI-Assisted Reporting\n\nArtificial Intelligence is no longer a futuristic concept in newsrooms—it's a present reality. From automated fact-checking to data analysis, AI tools are becoming indispensable for modern journalists.\n\n### Key Benefits:\n- **Speed**: Automated transcription and initial draft generation\n- **Accuracy**: Enhanced fact-checking capabilities\n- **Scale**: Ability to process vast amounts of data quickly\n- **Personalization**: Tailored content delivery to different audiences\n\n## Challenges and Ethical Considerations\n\nWhile technology offers tremendous opportunities, it also presents significant challenges. The spread of misinformation, deepfakes, and the erosion of trust in traditional media sources require journalists to be more vigilant than ever.\n\n## Looking Ahead\n\nThe future of journalism lies in embracing technology while maintaining the core principles that define our profession: accuracy, fairness, and accountability.",
+    "author": "Your Name",
+    "date": "2024-01-15",
+    "category": "Technology",
+    "readTime": "8 min read",
+    "image": "https://images.unsplash.com/photo-1504711434969-e33886168f5c?w=800&h=400&fit=crop",
+    "featured": true
+  },
+  {
+    "id": 2,
+    "title": "Investigative Reporting in the Digital Age",
+    "excerpt": "How modern tools and techniques are revolutionizing investigative journalism and uncovering stories that matter.",
+    "content": "# Investigative Reporting in the Digital Age\n\nModern investigative journalism has been transformed by digital tools and techniques that allow reporters to uncover stories with unprecedented depth and accuracy.\n\n## Digital Tools for Modern Investigators\n\nToday's investigative journalists have access to powerful tools that previous generations could only dream of:\n\n### Data Analysis Tools\n- Advanced spreadsheet software for pattern recognition\n- Database management systems for large datasets\n- Visualization tools for presenting complex information\n\n### Online Research Techniques\n- Social media investigation methods\n- Public records databases\n- Digital forensics tools\n\n## The Importance of Verification\n\nIn an era of information overload, verification has become more critical than ever. Investigative journalists must employ multiple verification methods to ensure accuracy.\n\n## Building Sources in the Digital World\n\nDeveloping and maintaining sources requires new approaches in our connected world, balancing accessibility with security and privacy concerns.",
+    "author": "Your Name",
+    "date": "2024-01-10",
+    "category": "Investigation",
+    "readTime": "6 min read",
+    "image": "https://images.unsplash.com/photo-1586953208448-b95a79798f07?w=800&h=400&fit=crop",
+    "featured": false
+  },
+  {
+    "id": 3,
+    "title": "Building Trust Through Transparent Reporting",
+    "excerpt": "Why transparency and accountability are more important than ever in today's media landscape.",
+    "content": "# Building Trust Through Transparent Reporting\n\nIn today's media landscape, trust between journalists and their audience is more crucial than ever. Transparency in reporting methods and accountability in storytelling are key to maintaining this trust.\n\n## The Trust Crisis in Media\n\nRecent surveys show declining trust in traditional media outlets. This crisis stems from various factors:\n\n- Perceived bias in reporting\n- Lack of transparency in sources\n- Speed over accuracy in breaking news\n- Echo chambers in digital media\n\n## Strategies for Transparent Reporting\n\n### Source Attribution\nWhenever possible, journalists should clearly identify their sources and explain why anonymity might be necessary when it is granted.\n\n### Methodology Disclosure\nExplaining how a story was researched and reported helps readers understand the journalistic process.\n\n### Correction Policies\nClear, prominent corrections and updates show commitment to accuracy.\n\n## The Role of Community Engagement\n\nEngaging with the community through comments, social media, and public forums helps build relationships and trust with readers.\n\n## Moving Forward\n\nThe future of journalism depends on rebuilding and maintaining trust through consistent, transparent, and accountable reporting practices.",
+    "author": "Your Name",
+    "date": "2024-01-05",
+    "category": "Ethics",
+    "readTime": "5 min read",
+    "image": "https://images.unsplash.com/photo-1585776245991-cf89dd7fc73a?w=800&h=400&fit=crop",
+    "featured": false
+  }
+]


### PR DESCRIPTION
## Summary
- load posts from `posts.json` instead of only local storage
- allow admin page to sync posts to GitHub using a personal access token
- add posts dataset in `posts.json`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68542031c154832499d56ec445906aee